### PR TITLE
added bitsery 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ endif()
 
 include_directories(${cpp_serializers_SOURCE_DIR})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Wextra -O2")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -Wextra -O2")
 
 find_package(ZLIB)
 if (NOT ZLIB_FOUND)
@@ -156,6 +156,21 @@ ExternalProject_Add(
     INSTALL_COMMAND mkdir -p ${cereal_PREFIX}/include/ && cp -r ${cereal_PREFIX}/src/cereal/include/cereal ${cereal_PREFIX}/include/
 )
 include_directories(${cereal_PREFIX}/include)
+
+set(bitsery_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/bitsery)
+ExternalProject_Add(
+    bitsery
+    PREFIX ${bitsery_PREFIX}
+    URL "https://github.com/fraillt/bitsery/archive/v4.0.0.tar.gz"
+    URL_MD5 "A5b2102a6177661bce5ddbcd9c982006"
+
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND mkdir -p ${bitsery_PREFIX}/include/ && cp -r ${bitsery_PREFIX}/src/bitsery/include/bitsery ${bitsery_PREFIX}/include/
+)
+include_directories(${bitsery_PREFIX}/include)
+
+
 
 set(avro_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external/avro)
 ExternalProject_Add(
@@ -305,6 +320,6 @@ add_executable(
     ${FLATBUFFERS_SERIALIZATION_SOURCES}
     ${YAS_SERIALIZATION_SOURCES}
 )
-add_dependencies(benchmark thrift msgpack protobuf capnproto boost cereal avro flatbuffers yas)
+add_dependencies(benchmark thrift msgpack protobuf capnproto boost cereal bitsery avro flatbuffers yas)
 target_link_libraries(benchmark ${LINKLIBS})
 set_target_properties(benchmark PROPERTIES COMPILE_FLAGS "-std=c++11")

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ $ cmake /path/to/cpp-serializers -DCMAKE_BUILD_TYPE=Release
 $ make
 ```
 
+#### Additional libraries required for building
+
+* `zlib` not found, install it via
+```
+$ apt-get install zlib1g-dev
+```
+* `autoreconf` not found, install it via
+```
+$ apt-get install dh-autoreconf
+```
+* building `thrift` requires openssl dev files installed, install it via
+```
+$ apt-get install libssl-dev
+```
+
 #### Usage
 * Test __all__ serializers, run each serializer 100000 times:
 ```

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -24,6 +24,7 @@
 #include "boost/record.hpp"
 #include "msgpack/record.hpp"
 #include "cereal/record.hpp"
+#include "bitsery/record.hpp"
 #include "avro/record.hpp"
 #include "flatbuffers/test_generated.h"
 #include "yas/record.hpp"
@@ -353,6 +354,52 @@ cereal_serialization_test(size_t iterations)
 }
 
 void
+bitsery_serialization_test(size_t iterations)
+{
+    using namespace bitsery_test;
+
+    Record r1, r2;
+
+    for (size_t i = 0; i < kIntegers.size(); i++) {
+        r1.ids.push_back(kIntegers[i]);
+    }
+
+    for (size_t i = 0; i < kStringsCount; i++) {
+        r1.strings.push_back(kStringValue);
+    }
+
+    std::vector<uint8_t> buf;
+    r2.strings = r1.strings;
+    r2.ids = r1.ids;
+    auto writtenSize = bitsery_serialize(r1, buf);
+    bitsery_deserialize(r2, buf, writtenSize);
+
+    if (r1 != r2) {
+        throw std::logic_error("bitsery's case: deserialization failed");
+    }
+    std::cout << "bitsery: version = " << BITSERY_VERSION << std::endl;
+    std::cout << "bitsery: size = " << writtenSize << " bytes" << std::endl;
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i < iterations; i++) {
+        buf.clear();
+        auto writtenSize = bitsery_serialize(r1, buf);
+        bitsery_deserialize(r2, buf, writtenSize);
+    }
+    auto finish = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(finish - start).count();
+
+    std::cout << "bitsery: time = " << duration << " milliseconds" << std::endl << std::endl;
+}
+
+
+
+
+
+
+
+
+void
 avro_serialization_test(size_t iterations)
 {
     using namespace avro_test;
@@ -366,6 +413,7 @@ avro_serialization_test(size_t iterations)
     for (size_t i = 0; i < kStringsCount; i++) {
         r1.strings.push_back(kStringValue);
     }
+    r2.strings.resize(100);
 
     std::unique_ptr<avro::OutputStream> out = avro::memoryOutputStream();
     avro::EncoderPtr encoder = avro::binaryEncoder();
@@ -525,7 +573,7 @@ main(int argc, char** argv)
 
     if (argc < 2) {
         std::cout << "usage: " << argv[0]
-                  << " N [thrift-binary thrift-compact protobuf boost msgpack cereal avro capnproto flatbuffers yas yas-compact]";
+                  << " N [thrift-binary thrift-compact protobuf boost msgpack cereal vro capnproto flatbuffers yas yas-compact bitsery]";
         std::cout << std::endl << std::endl;
         std::cout << "arguments: " << std::endl;
         std::cout << " N  -- number of iterations" << std::endl << std::endl;
@@ -582,6 +630,10 @@ main(int argc, char** argv)
         if (names.empty() || names.find("cereal") != names.end()) {
             cereal_serialization_test(iterations);
         }
+
+        if (names.empty() || names.find("bitsery") != names.end()) {
+            bitsery_serialization_test(iterations);
+        }        
 
         if (names.empty() || names.find("avro") != names.end()) {
             avro_serialization_test(iterations);

--- a/bitsery/record.hpp
+++ b/bitsery/record.hpp
@@ -1,0 +1,58 @@
+#ifndef __BITSERY_RECORD_HPP_INCLUDED__
+#define __BITSERY_RECORD_HPP_INCLUDED__
+
+#include <vector>
+#include <string>
+#include <bitsery/bitsery.h>
+#include <bitsery/adapter/buffer.h>
+
+#include <bitsery/flexible.h>
+#include <bitsery/flexible/vector.h>
+#include <bitsery/flexible/string.h>
+
+#include <memory>
+
+namespace bitsery_test {
+
+typedef std::vector<int64_t>     Integers;
+typedef std::vector<std::string> Strings;
+
+class Record {
+public:
+
+    Integers ids;
+    Strings  strings;
+
+    bool operator==(const Record &other) {
+        return (ids == other.ids && strings == other.strings);
+    }
+
+    bool operator!=(const Record &other) {
+        return !(*this == other);
+    }
+
+    template <typename S>
+    void serialize(S& s) {
+        //maxSize - enforces container max size
+//        s.archive(
+//                bitsery::maxSize(ids, 1000000),
+//                bitsery::maxSize(strings, 1000000));
+        //optionally you can use like this, without maxSize restriction
+        s.archive(ids,strings);
+    }
+};
+
+using OutputAdapter = bitsery::OutputBufferAdapter<std::vector<uint8_t>>;
+using InputAdapter = bitsery::InputBufferAdapter<std::vector<uint8_t>>;
+
+size_t bitsery_serialize(const Record &record, std::vector<uint8_t> &data) {
+    return bitsery::quickSerialization<OutputAdapter>({data}, record);
+}
+
+void bitsery_deserialize(Record &record, std::vector<uint8_t> &data, size_t writtenSize) {
+    bitsery::quickDeserialization<InputAdapter>(InputAdapter{data.begin(), writtenSize}, record);
+};
+
+} // namespace
+
+#endif


### PR DESCRIPTION
added new serializer.
need to update graphs before mergint to master.
where is results with Clang 4.0.0 on Ubuntu 16.04 x64.

performing 1000000 iterations

thrift-binary: version = 0.10.0
thrift-binary: size = 17017 bytes
thrift-binary: time = 8532 milliseconds

thrift-compact: version = 0.10.0
thrift-compact: size = 13378 bytes
thrift-compact: time = 23697 milliseconds

protobuf: version = 3001000
protobuf: size = 16116 bytes
protobuf: time = 18182 milliseconds

capnproto: version = 6001
capnproto: size = 17768 bytes
capnproto: time = 3112 milliseconds

boost: version = 106200
boost: size = 17470 bytes
boost: time = 8984 milliseconds

msgpack: version = 2.1.3
msgpack: size = 13402 bytes
msgpack: time = 19941 milliseconds

cereal: size = 17416 bytes
cereal: time = 7221 milliseconds

bitsery: size = 16703 bytes
bitsery: time = 2454 milliseconds

avro: size = 16384 bytes
avro: time = 31089 milliseconds

flatbuffers: size = 17632 bytes
flatbuffers: time = 4537 milliseconds

yas: version = 5.0.0
yas: size = 17416 bytes
yas: time = 2405 milliseconds

yas-compact: version = 5.0.0
yas-compact: size = 13553 bytes
yas-compact: time = 21996 milliseconds
