### PR TITLE
Fixed "Unknown extension"-problem during CMake init.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-project(cpp_serializers LANGUAGES CXX VERSION 0.1.0)
+project(cpp_serializers LANGUAGES CXX C VERSION 0.1.0)
 
 if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(FATAL_ERROR "Doesn't support non 64-bit platforms")


### PR DESCRIPTION
When running CMake to initialize the build folder, the following error
occured:

```
-- Looking for include file inttypes.h
CMake Error at /usr/share/cmake-3.10/Modules/CheckIncludeFiles.cmake:69 (try_compile):
  Unknown extension ".c" for file

    /home/pkok/cpp-serializers/build/CMakeFiles/CMakeTmp/CheckIncludeFiles.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX

  See project() command to enable other languages.
Call Stack (most recent call first):
  CMakeLists.txt:23 (CHECK_INCLUDE_FILES)

-- Looking for include file inttypes.h - not found
-- Looking for include file netinet/in.h
CMake Error at /usr/share/cmake-3.10/Modules/CheckIncludeFiles.cmake:69 (try_compile):
  Unknown extension ".c" for file

    /home/pkok/cpp-serializers/build/CMakeFiles/CMakeTmp/CheckIncludeFiles.c

  try_compile() works only for enabled languages.  Currently these are:

    CXX

  See project() command to enable other languages.
Call Stack (most recent call first):
  CMakeLists.txt:24 (CHECK_INCLUDE_FILES)
```

This seems to be [a common
problem](http://www.grokit.ca/cnt/CMakeProblemsSolutions/).  This can be
fixed by telling CMake that you also want to use the C language in the
project.  This has been done in l.2 of `CMakeLists.txt`.